### PR TITLE
Fix UBSAN: Pass NULL as source to memcpy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scrypt
 Type: Package
 Title: Key Derivation Functions for R Based on Scrypt
-Version: 0.1.3-9000
+Version: 0.1.4
 Authors@R: c(
     person("Bob", "Jansen", email = "bobjansen@gmail.com", role = c("ctb", "cre")),
     person("Andy", "Kipp", email = "andy@rstudio.com", role = c("aut")),

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,10 @@
-scrypt 0.1.4  (UNRELEASED)
+scrypt 0.1.4
 --------------------------------------------------------------------------------
 
 * Removed redundant usages of Rcpp:::CxxFlags() and Rcpp:::LdFlags()
+* Fix UBSAN issue flagged by CRAN: The salt parameter of crypto_scrypt() was
+  set to NULL in getcpupref(). This NULL value was used as src in a call to
+  memcpy()
 
 scrypt 0.1.3
 --------------------------------------------------------------------------------

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -128,6 +128,7 @@ int getcpuperf(double *opps)
     struct timespec st;
     double resd, diffd;
     uint64_t i = 0;
+    uint8_t salt[32] = {0};
 
     /* Get the clock resolution. */
     if (getclockres(&resd))
@@ -142,7 +143,7 @@ int getcpuperf(double *opps)
         return (2);
     do {
         /* Do an scrypt. */
-        if (crypto_scrypt(NULL, 0, NULL, 0, 16, 1, 1, NULL, 0))
+        if (crypto_scrypt(NULL, 0, salt, 0, 16, 1, 1, NULL, 0))
             return (3);
 
         /* Has the clock ticked? */
@@ -157,7 +158,7 @@ int getcpuperf(double *opps)
         return (2);
     do {
         /* Do an scrypt. */
-        if (crypto_scrypt(NULL, 0, NULL, 0, 128, 1, 1, NULL, 0))
+        if (crypto_scrypt(NULL, 0, salt, 0, 128, 1, 1, NULL, 0))
             return (3);
 
         /* We invoked the salsa20/8 core 512 times. */
@@ -171,7 +172,7 @@ int getcpuperf(double *opps)
     } while (1);
 
 #ifdef DEBUG
-    REprintf("%ju salsa20/8 cores performed in %f seconds\n", 
+    REprintf("%ju salsa20/8 cores performed in %f seconds\n",
         (uintmax_t)i, diffd);
 #endif
 
@@ -284,10 +285,10 @@ int getsalt(uint8_t salt[32]) {
     } else {
         goto err;
     }
-    
+
     /* Success! */
     return (0);
-    
+
 #else
 
     int fd;


### PR DESCRIPTION
It's not allowed to pass `NULL` as a source to `memcpy()`. This was done twice in `getcpuperf()`, [see this issue](https://github.com/bobjansen/rscrypt/issues/1).

These commits fix the issue by creating a salt of all `0` and bumps the version to 0.1.4.

To keep the package on CRAN action should be taken before 25 April. If I receive no comments, I plan to submit to CRAN on the 16th.